### PR TITLE
Add error handling to model caching

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -512,23 +512,31 @@ def get_model_flexible(model, content):
 
 def get_model_info(model):
     if not litellm._lazy_module:
+        use_cache = True
         cache_dir = Path.home() / ".aider" / "caches"
         cache_file = cache_dir / "model_prices_and_context_window.json"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            use_cache = False
+            print(f"Warning: Could not create cache directory {cache_dir}: {e}")
 
-        current_time = time.time()
-        cache_age = (
-            current_time - cache_file.stat().st_mtime if cache_file.exists() else float("inf")
-        )
+        if use_cache:
+            current_time = time.time()
+            cache_age = (
+                current_time - cache_file.stat().st_mtime
+                if cache_file.exists()
+                else float("inf")
+            )
 
-        if cache_age < 60 * 60 * 24:
-            try:
-                content = json.loads(cache_file.read_text())
-                res = get_model_flexible(model, content)
-                if res:
-                    return res
-            except Exception as ex:
-                print(str(ex))
+            if cache_age < 60 * 60 * 24:
+                try:
+                    content = json.loads(cache_file.read_text())
+                    res = get_model_flexible(model, content)
+                    if res:
+                        return res
+                except Exception as ex:
+                    print(str(ex))
 
         import requests
 
@@ -536,7 +544,11 @@ def get_model_info(model):
             response = requests.get(model_info_url, timeout=5)
             if response.status_code == 200:
                 content = response.json()
-                cache_file.write_text(json.dumps(content, indent=4))
+                if use_cache:
+                    try:
+                        cache_file.write_text(json.dumps(content, indent=4))
+                    except OSError as e:
+                        print(f"Warning: Could not write to cache file {cache_file}: {e}")
                 res = get_model_flexible(model, content)
                 if res:
                     return res


### PR DESCRIPTION
Add `OSError` handling to `get_model_info` to disable caching on directory creation failure and log errors on file write failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-2665b24f-25d1-47c1-8680-8ef862f033ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2665b24f-25d1-47c1-8680-8ef862f033ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

